### PR TITLE
Implement `additionalSelectors` secondary option

### DIFF
--- a/.changeset/famous-groups-peel.md
+++ b/.changeset/famous-groups-peel.md
@@ -1,0 +1,7 @@
+---
+"stylelint-plugin-a11y-contemporary": minor
+---
+
+Add `additionalSelectors` secondary option, to allow specifying any custom
+selectors that should be targeted, in addition to the built-in
+:focus/:focus-visible/:focus-within.

--- a/.changeset/icy-turtles-open.md
+++ b/.changeset/icy-turtles-open.md
@@ -1,0 +1,5 @@
+---
+"stylelint-plugin-a11y-contemporary": patch
+---
+
+Ensure that autofix also removes `outline: none` declarations

--- a/docs/rules/focus-use-outline.md
+++ b/docs/rules/focus-use-outline.md
@@ -1,6 +1,6 @@
 # focus-use-outline
 
-Encourages use of `outline` for styling focus indicators, over `box-shadow`.
+Encourages the use of `outline` for styling focus indicators, over `box-shadow`.
 
 Reasoning:
 
@@ -27,6 +27,10 @@ The following patterns are considered problems:
 :focus-within {
   box-shadow: 0 0 0 3px red;
 }
+:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px red;
+}
 ```
 
 The following patterns are _not_ considered problems:
@@ -41,11 +45,36 @@ The following patterns are _not_ considered problems:
 :focus-within {
   outline: 3px solid blue;
 }
+
+/* box-shadow can co-exist with outline, if the outline is not reset fully */
 :focus {
   outline: 3px solid blue;
-
-  /* Any box-shadow can co-exist with outline */
   box-shadow: 0 0 0 3px red;
+}
+```
+
+## Secondary options
+
+### `additionalSelectors`
+
+By default, this rule considers any selector that includes `:focus`,
+`:focus-visible` and `:focus-within` to be a focus-related style.
+
+Sometimes, depending on polyfills, browser bug workarounds, or code
+organisation, you might be using additional selectors to indicate focus-related
+styles, such as `.focus-visible`.
+
+You can provide `additionalSelectors`, to allow the plugin to target those
+rules.
+
+```json
+{
+  "rules": {
+    "a11y-contemporary/focus-use-outline": [
+      true,
+      { "additionalSelectors": [".focus-visible"] }
+    ]
+  }
 }
 ```
 
@@ -61,3 +90,7 @@ to create a focus indicator that is visible on multiple backgrounds. If you are
 doing this, you can still use this rule, and set an outline like
 `outline: 2px solid transparent`, so that you preserve forced-colors mode
 compatibility.
+
+```
+
+```

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "postcss": "^8.5.3"
+    "postcss": "^8.5.3",
+    "postcss-values-parser": "^6.0.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
+      postcss-values-parser:
+        specifier: ^6.0.2
+        version: 6.0.2(postcss@8.5.3)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 0.17.4
@@ -1266,6 +1269,10 @@ packages:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
 
+  is-url-superb@4.0.0:
+    resolution: {integrity: sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==}
+    engines: {node: '>=10'}
+
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
@@ -1710,6 +1717,12 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
+  postcss-values-parser@6.0.2:
+    resolution: {integrity: sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      postcss: ^8.2.9
+
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1751,6 +1764,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quote-unquote@1.0.0:
+    resolution: {integrity: sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==}
 
   read-package-json-fast@4.0.0:
     resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
@@ -3325,6 +3341,8 @@ snapshots:
     dependencies:
       better-path-resolve: 1.0.0
 
+  is-url-superb@4.0.0: {}
+
   is-windows@1.0.2: {}
 
   isexe@2.0.0: {}
@@ -3854,6 +3872,13 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
+  postcss-values-parser@6.0.2(postcss@8.5.3):
+    dependencies:
+      color-name: 1.1.4
+      is-url-superb: 4.0.0
+      postcss: 8.5.3
+      quote-unquote: 1.0.0
+
   postcss@8.5.3:
     dependencies:
       nanoid: 3.3.8
@@ -3885,6 +3910,8 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  quote-unquote@1.0.0: {}
 
   read-package-json-fast@4.0.0:
     dependencies:

--- a/src/rules/focus-use-outline.spec.ts
+++ b/src/rules/focus-use-outline.spec.ts
@@ -19,6 +19,7 @@ testRule({
   plugins,
   ruleName,
   config: [true],
+  fix: true,
   accept: [
     {
       code: ":focus { outline: 2px solid blue; }",
@@ -30,12 +31,15 @@ testRule({
       code: ":focus-within { outline: 2px solid blue; }",
     },
     {
+      // Both box-shadow and outline are allowed
       code: ":focus { outline: 2px solid blue; box-shadow: 0 0 0 2px red; }",
     },
     {
+      // Ditto
       code: ":focus { outline: 2px solid transparent; box-shadow: 0 0 0 2px red; }",
     },
     {
+      // Nesting
       code: "a { :focus { outline: 2px solid blue; box-shadow: 0 0 0 2px red; }}",
     },
     {
@@ -58,18 +62,56 @@ testRule({
   reject: [
     {
       code: ":focus { box-shadow: 0 0 0 2px red; }",
+      fixed: ":focus { outline: 2px solid red; }",
       message: messages.noBoxShadow,
     },
     {
       code: ":focus-visible { box-shadow: 0 0 0 2px red; }",
+      fixed: ":focus-visible { outline: 2px solid red; }",
       message: messages.noBoxShadow,
     },
     {
       code: ":focus-within { box-shadow: 0 0 0 2px red; }",
+      fixed: ":focus-within { outline: 2px solid red; }",
+      message: messages.noBoxShadow,
+    },
+    // If an outline is reset altogether, then box-shadow is disallowed
+    {
+      code: ":focus { outline: none; box-shadow: 0 0 0 2px red; }",
+      fixed: ":focus { outline: 2px solid red; }",
+      message: messages.noBoxShadow,
+    },
+    // nesting
+    {
+      code: "a { &:focus { box-shadow: 0 0 0 2px red; }}",
+      fixed: "a { &:focus { outline: 2px solid red; }}",
+      message: messages.noBoxShadow,
+    },
+    // inset
+    {
+      code: ":focus { box-shadow: inset 0 0 0 2px red; }",
+      fixed:
+        ":focus { outline: 2px solid red; outline-offset: calc(-1 * 2px); }",
+      message: messages.noBoxShadow,
+    },
+  ],
+});
+
+// Custom selectors
+testRule({
+  plugins,
+  ruleName,
+  config: [
+    true,
+    { additionalSelectors: [":custom-focus-visible", ".focus-visible"] },
+  ],
+  reject: [
+    {
+      code: ":custom-focus-visible { box-shadow: 0 0 0 2px blue; }",
       message: messages.noBoxShadow,
     },
     {
-      code: "a { &:focus { box-shadow: 0 0 0 2px red; }}",
+      code: ".focus-visible { box-shadow: 0 0 0 2px blue; }",
       message: messages.noBoxShadow,
     },
   ],


### PR DESCRIPTION
This PR adds `additionalSelectors`, as a way to opt-in to checks for custom selectors, such as `.focus-visible`.
